### PR TITLE
Closes #19

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,14 +62,3 @@ Errors / Bugs
 Experiencing issues with the included files? Report it on our `issue
 tracker
 <https://github.com/Chicago/open-data-etl-utility-kit/issues>`__
-
-Table of Contents
-=================
-.. toctree::
-   :maxdepth: 1
-
-   installation-configuration
-   creating-configuring-ETL
-   setting-up-automation
-   utilities-for-administering-etls
-


### PR DESCRIPTION
As pointed out by @fgregg, it appears that duplicated `toctree` was introduced in f520a695ed428cbd82965e5448fd9fc16a7a7f73 and created the duplicated table of contents in RTD. This fix was [tested and passed on the dev RTD page](http://open-data-etl-utility-kit-dev.readthedocs.org/).
