### PR TITLE
Issue 3

### DIFF
--- a/Log/A_DatasetLogs.bat
+++ b/Log/A_DatasetLogs.bat
@@ -1,0 +1,7 @@
+@echo off
+IF [%1] == [] GOTO USAGE
+dir /b | find "%1"
+exit /B
+
+:USAGE
+echo Usage: A_DatasetLogs.bat StringToFindInLogName

--- a/Log/A_ETLRuntimes.bat
+++ b/Log/A_ETLRuntimes.bat
@@ -1,6 +1,6 @@
 @echo off
 IF [%1] == [] GOTO USAGE
-copy *%1* con | find "Processing ended after"
+type *%1* 2>nul | find "Processing ended after"
 exit /B
 
 :USAGE

--- a/Log/A_ETLRuntimes.bat
+++ b/Log/A_ETLRuntimes.bat
@@ -1,0 +1,8 @@
+@echo off
+IF [%1] == [] GOTO USAGE
+copy *%1* con | find "Processing ended after"
+exit /B
+
+:USAGE
+echo Usage: A_DatasetLogs.bat StringToFindInLogName
+exit /B 1

--- a/Log/A_ETLRuntimes.bat
+++ b/Log/A_ETLRuntimes.bat
@@ -4,5 +4,5 @@ copy *%1* con | find "Processing ended after"
 exit /B
 
 :USAGE
-echo Usage: A_DatasetLogs.bat StringToFindInLogName
+echo Usage: A_ETLRuntimes.bat StringToFindInLogName
 exit /B 1

--- a/Log/A_RunETL.bat
+++ b/Log/A_RunETL.bat
@@ -1,0 +1,8 @@
+@echo off
+IF [%1] == [] GOTO USAGE
+schtasks /Query /FO list /V | FOR /F "tokens=2 DELIMS=:" %%f in ('findstr /RC:"^Task To Run"') do @FOR /F "tokens=* delims= " %%a in ('@echo %%f') do @echo %%a | find %1%"
+exit /B
+
+:USAGE
+echo Usage: A_RunETL.bat Dataset4x4
+exit /B 1

--- a/Log/A_RunETL.bat
+++ b/Log/A_RunETL.bat
@@ -1,6 +1,6 @@
 @echo off
 IF [%1] == [] GOTO USAGE
-schtasks /Query /FO list /V | FOR /F "tokens=2 DELIMS=:" %%f in ('findstr /RC:"^Task To Run"') do @FOR /F "tokens=* delims= " %%a in ('@echo %%f') do @echo %%a | find %1%"
+schtasks /Query /FO list /V FOR /F "tokens=2 DELIMS=:" %%f in ('findstr /RC:"^Task To Run"') do @FOR /F "tokens=* delims= " %%a in ('@echo %%f') do @echo %%a | FOR /F "tokens=*" %%b in ('find "%1"') do @call %%b
 exit /B
 
 :USAGE

--- a/Log/A_RunETL.bat
+++ b/Log/A_RunETL.bat
@@ -1,6 +1,14 @@
 @echo off
 IF [%1] == [] GOTO USAGE
-schtasks /Query /FO list /V FOR /F "tokens=2 DELIMS=:" %%f in ('findstr /RC:"^Task To Run"') do @FOR /F "tokens=* delims= " %%a in ('@echo %%f') do @echo %%a | FOR /F "tokens=*" %%b in ('find "%1"') do @call %%b
+
+REM Sanity check
+echo %1 | findstr /r "\<[a-Z0123456789][a-Z0123456789][a-Z0123456789][a-Z0123456789]-[a-Z0123456789][a-Z0123456789][a-Z0123456789][a-Z0123456789]\>"
+IF %ERRORLEVEL% NEQ 0 (
+  echo Invalid Dataset4x4
+  exit /B 1
+)
+
+schtasks /Query /FO list /V | FOR /F "tokens=2 DELIMS=:" %%f in ('findstr /RC:"^Task To Run"') do @FOR /F "tokens=* delims= " %%a in ('@echo %%f') do @echo %%a | FOR /F "tokens=*" %%b in ('find "%1"') do @call %%b
 exit /B
 
 :USAGE

--- a/Log/A_RunETL.sh
+++ b/Log/A_RunETL.sh
@@ -3,6 +3,11 @@ then
    echo "Usage: A_RunETL.sh Dataset4x4"
    exit 1
 else
+   # Sanity check
+   if [ -z $(echo "$1" | grep "^[a-zA-Z0-9]\{4\}-[a-zA-Z0-9]\{4\}$") ]; then
+      echo "Invalid Dataset4x4"
+      exit 1
+   fi
    CRONTAB_LINE="crontab -l | grep $1 | cut -d ' ' -f 6-"   #Returns the 6th and subsequent "fields" from the crontab line containing the 4x4, with the field delimiter being a space. Result: Skips the scheduling part and returns the actual command.
    COMMAND_TO_RUN=$(eval $CRONTAB_LINE)
    eval $COMMAND_TO_RUN

--- a/Log/A_TodayLogs.bat
+++ b/Log/A_TodayLogs.bat
@@ -7,9 +7,7 @@ IF [%1] == [] GOTO DEFAULT
 IF [%1] == [-e] GOTO EXCLUDE
 
 echo Usage: A_Today.bat [-e]
-echo    -e Exclude a pre-specified set of datasets by 4x4. generally those that run 
-
-frequently and would clutter the output.
+echo    -e Exclude a pre-specified set of datasets by 4x4. generally those that run frequently and would clutter the output.
 exit /B 1
 
 :DEFAULT

--- a/Log/A_TodayLogs.bat
+++ b/Log/A_TodayLogs.bat
@@ -1,0 +1,20 @@
+@echo off
+REM Specify the 4x4 values to exclude, separated by space characters
+set DATASETS_TO_EXCLUDE="n4j6-wkkf t2qx-9pjd qmqz-2xku 97wa-y6ff"
+set TODAY=%date:~10,4%%date:~4,2%%date:~7,2%
+
+IF [%1] == [] GOTO DEFAULT
+IF [%1] == [-e] GOTO EXCLUDE
+
+echo Usage: A_Today.bat [-e]
+echo    -e Exclude a pre-specified set of datasets by 4x4. generally those that run 
+
+frequently and would clutter the output.
+exit /B 1
+
+:DEFAULT
+dir /b | find "%TODAY%"
+exit /B
+
+:EXCLUDE
+dir /b | find "%TODAY%" | findstr /V %DATASETS_TO_EXCLUDE%

--- a/docs/utilities-for-administering-etls.rst
+++ b/docs/utilities-for-administering-etls.rst
@@ -49,10 +49,21 @@ Show all log files
 
 **Returns:** Will list the log files associated for a user-specified ETL job. The output is displayed in the terminal.
 
+**File:** Log/A_DatasetLogs.bat (Windows only)
+ 
+**Description:** Shows all of the log files associated with a dataset.
+ 
+**Usage:** Open the command prompt window and type the name of a dataset::
+ 	
+	> cd \path\to\directory\open-data-etl-utility-kit\
+	> \Log\A_DatasetLogs.bat Name_of_dataset
+ 
+**Returns:** Will list the log files associated for a user-specified ETL job. The output is displayed in the command prompt window.
+
 Summarize ETL run times
 -----------------------
 
-**File:** Log/A_DatasetLogs.sh (MacOS X/Linux/Unix only)
+**File:** Log/A_ETLRuntimes.sh (MacOS X/Linux/Unix only)
 
 **Description:** Shows the runtime for ETLs with a dataset.
 
@@ -62,6 +73,17 @@ Summarize ETL run times
 	$ sh Log/A_ETLRuntimes.sh Name_of_dataset
 
 **Returns:** The output will show the total run-times recorded in log files for the user-specified ETL. The output is displayed in the terminal.
+
+**File:** Log/A_ETLRuntimes.bat (Windows only)
+
+**Description:** Shows the runtime for ETLs with a dataset.
+
+**Usage:** Open the command prompt window and type the name of a dataset::
+
+	> cd \path\to\directory\open-data-etl-utility-kit\
+	> Log\A_ETLRuntimes.bat Name_of_dataset
+
+**Returns:** The output will show the total run-times recorded in log files for the user-specified ETL. The output is displayed in the command prompt window.
 
 Show today's ETL logs
 ---------------------
@@ -76,6 +98,16 @@ Show today's ETL logs
 
 **Returns:** The output will show the list of log files which were generated today. With the *-e* parameter, a group of datasets specified in a parameter at the beginning of the script will be excluded (generally, those that run frequently and would clutter the output). The output is displayed in the terminal.
 
+**File:** Log/A_TodayLogs.bat (Windows only)
+
+**Description:** Shows log files which were created today
+
+**Usage:** Open the command prompt window and run the command::
+
+	> sh \path\to\directory\open-data-etl-utility-kit\Log\A_TodayLogs.bat [-e]
+
+**Returns:** The output will show the list of log files which were generated today. With the *-e* parameter, a group of datasets specified in a parameter at the beginning of the script will be excluded (generally, those that run frequently and would clutter the output). The output is displayed in the command prompt window.
+
 Run a specific ETL
 ---------------------
 
@@ -87,5 +119,17 @@ Run a specific ETL
 
 	$ cd /path/to/directory/open-data-etl-utility-kit/
 	$ sh Log/A_RunETL.sh Name_of_dataset
+
+**Returns:** The script will find and run the ETL command for the specified dataset. The output will show the command run so the user can confirm it was the intended dataset ETL.
+
+
+**File:** Log/A_RunETL.bat (Windows only)
+
+**Description:** Performs a one-time run of an ETL normally run on a scheduled basis through by the Windows task scheduler.  This file need not be in the Log directory to run correctly.  It does not use the log files and is in the Log directory only to keep it with other scripts.
+
+**Usage:** Open the terminal and type the name of a dataset::
+
+	$ cd \path\to\directory\open-data-etl-utility-kit\
+	$ Log\A_RunETL.bat Name_of_dataset
 
 **Returns:** The script will find and run the ETL command for the specified dataset. The output will show the command run so the user can confirm it was the intended dataset ETL.


### PR DESCRIPTION
Per Issue 3, created A_DatasetLogs.bat, A_ETL_Runtimes.bat, A_RunETL.bat, A_TodayLogs.bat to mimic the functionality of the corresponding shell scripts.  Care has been taken to avoid dependencies, other than a modern windows command interpreter.  However:

* A_RunETL.bat uses the Windows Task Scheduler as an analog to cron, and relies on the command line interface schtasks.exe, which appears in Windows XP or newer workstations, and Windows 2003 and newer servers.

* In A_TodayLogs.bat, the correct setting of the TODAY variable assumes the default date format for English - United States (en-us).  Different locales may require tweaking.

* In A_TodayLogs.bat, the delimiter for DATASETS_TO_EXCLUDE has been changed from the pipe symbol (|) to a space ( ) for compatibility with the FINDSTR command.

**Without a set of example log files, testing has been very limited, please construct your test plan accordingly.**
